### PR TITLE
Allow action bodies to return conn and fix transitions

### DIFF
--- a/lib/mazurka_plug.ex
+++ b/lib/mazurka_plug.ex
@@ -37,7 +37,7 @@ defmodule Mazurka.Plug do
                 Mazurka.MissingParametersException,
                 Mazurka.MissingRouterException] ->
         %{conn: conn} = err
-        Plug.Conn.WrapperError.reraise(conn, :error, err, System.stacktrace())
+        Plug.Conn.WrapperError.reraise(conn, :error, err)
       end
 
       def send_resp(conn, _opts) do

--- a/lib/mazurka_plug.ex
+++ b/lib/mazurka_plug.ex
@@ -12,7 +12,6 @@ defmodule Mazurka.Plug do
         end
       end)
 
-      @doc false
       def action(conn, opts) when is_list(opts) do
         action(conn, :maps.from_list(opts))
       end

--- a/lib/mazurka_plug.ex
+++ b/lib/mazurka_plug.ex
@@ -37,7 +37,7 @@ defmodule Mazurka.Plug do
                 Mazurka.MissingParametersException,
                 Mazurka.MissingRouterException] ->
         %{conn: conn} = err
-        Plug.Conn.WrapperError.reraise(conn, :error, err)
+        Plug.Conn.WrapperError.reraise(conn, :error, err, System.stacktrace())
       end
 
       def send_resp(conn, _opts) do

--- a/lib/mazurka_plug.ex
+++ b/lib/mazurka_plug.ex
@@ -57,7 +57,7 @@ defmodule Mazurka.Plug do
   def serialize({"text", "html", _}, body) when is_tuple(body) do
     HTMLBuilder.encode_to_iodata!(body)
   end
-  def serialize({"text", _, _}, body) do
+  def serialize(_, body) do
     body
   end
 

--- a/lib/mazurka_plug/helpers.ex
+++ b/lib/mazurka_plug/helpers.ex
@@ -42,15 +42,25 @@ defmodule Mazurka.Plug.Helpers do
     {params, input, conn}
   end
 
+  def handle_body(_conn, %Plug.Conn{} = conn, content_type, serialize) do
+    handle_body(conn, conn.resp_body, content_type, serialize)
+  end
+
   def handle_body(conn, body, {type, subtype, _} = content_type, serialize) do
     body = serialize.(content_type, body)
     %{conn | resp_body: body, state: :set}
     |> Conn.put_resp_content_type(type <> "/" <> subtype)
   end
 
-  def handle_transition(%{private: %{mazurka_transition: transition}, status: status} = conn) do
-    %{conn | status: status || 303}
+  def handle_transition(%{private: %{mazurka_transition: _} = private} = conn) do
+    {transition, private} = Map.pop(private, :mazurka_transition)
+
+    %{conn | status: conn.status || 303}
     |> Conn.put_resp_header("location", to_string(transition))
+    |> handle_transition()
+  end
+  def handle_transition(%{status: status} = conn) when status >= 300 and status < 400 do
+    %{conn | resp_body: ""}
   end
   def handle_transition(conn) do
     conn

--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,15 @@ defmodule Mazurka.Plug.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :mazurka_plug,
-     description: "Plug integration for Mazurka",
-     version: "0.1.7",
-     elixir: "~> 1.0",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     package: package(),
-     deps: deps()]
+    [
+      app: :mazurka_plug,
+      description: "Plug integration for Mazurka",
+      version: "0.1.7",
+      elixir: "~> 1.0",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
   end
 
   def application do
@@ -17,18 +18,13 @@ defmodule Mazurka.Plug.Mixfile do
   end
 
   defp deps do
-    [{:fugue, ">= 0.1.0"},
-     {:html_builder, "~> 0.1"},
-     {:mazurka, ">= 1.0.0"},
-     {:plug, ">= 0.0.0"},
-     {:poison, ">= 2.2.0"},
-     {:ex_doc, ">= 0.0.0", only: :dev}]
-  end
-
-  defp package do
-    [files: ["lib", "mix.exs", "README*"],
-     maintainers: ["Cameron Bytheway"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/exstruct/mazurka_plug"}]
+    [
+      {:fugue, ">= 0.1.0"},
+      {:html_builder, github: "simplecastapps/html_builder"},
+      {:mazurka, github: "simplecastapps/mazurka"},
+      {:plug, ">= 0.0.0"},
+      {:poison, ">= 2.2.0"},
+      {:ex_doc, ">= 0.0.0", only: :dev}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Mazurka.Plug.Mixfile do
   def project do
     [app: :mazurka_plug,
      description: "Plug integration for Mazurka",
-     version: "0.1.6",
+     version: "0.1.7",
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -14,17 +14,19 @@ defmodule Mazurka.Plug.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [
+      applications: [:logger]
+    ]
   end
 
   defp deps do
     [
+      {:ex_doc, ">= 0.0.0", only: :dev},
       {:fugue, ">= 0.1.0"},
       {:html_builder, github: "simplecastapps/html_builder"},
       {:mazurka, github: "simplecastapps/mazurka"},
       {:plug, ">= 0.0.0"},
-      {:poison, ">= 2.2.0"},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:poison, ">= 2.2.0"}
     ]
   end
 end


### PR DESCRIPTION
- Allows a resource `action` to return a `conn`, which is treated as the new current `conn` instead of the response body.
- When transitioning, set the response body to an empty binary as it should.